### PR TITLE
Fix upgrade from 0.15

### DIFF
--- a/check_process
+++ b/check_process
@@ -27,6 +27,7 @@
 		setup_private=1
 		setup_public=1
 		upgrade=1
+		upgrade=1	from_commit=adb788162e27a843d52582cb03106861e1b17c9c
 		upgrade=1	from_commit=30d48110ea0c820c89ab8ade34e415f07b5b0b86
 		backup_restore=1
 		multi_instance=1
@@ -39,5 +40,8 @@ Email=
 Notification=none
 ;;; Upgrade options
 	; commit=30d48110ea0c820c89ab8ade34e415f07b5b0b86
-		name=Merge pull request #13 from YunoHost-Apps/testing 
+		name=Merge pull request #13 from YunoHost-Apps/testing
+		manifest_arg=domain=DOMAIN&path=PATH&is_public=1&data_path=""&master_key="YUNOHOST-API-KEY-202020201456452135"&
+	; commit=adb788162e27a843d52582cb03106861e1b17c9c
+		name=From Version 0.15.0ynh~1 (Fixes #14)
 		manifest_arg=domain=DOMAIN&path=PATH&is_public=1&data_path=""&master_key="YUNOHOST-API-KEY-202020201456452135"&

--- a/check_process
+++ b/check_process
@@ -1,8 +1,22 @@
-;; Test name
+;; Meilisearch_ynh
 # Comment ignored
-	; pre-install
-		echo -n "Here your commands to execute in the container"
-		echo ", before each installation of the app."
+	; pre-upgrade
+		set -euxo pipefail
+		if [ "$FROM_COMMIT" == "adb788162e27a843d52582cb03106861e1b17c9c" ]
+		then
+			resolve=$SUBDOMAIN:443:127.0.0.1
+			api_key="X-Meili-API-Key: YUNOHOST-API-KEY-202020201456452135"
+			curl -k --silent --fail -X POST "https://$SUBDOMAIN/indexes" --data '{"uid": "test", "primaryKey": "id"}' --header "$api_key" --resolve "$resolve"
+			sleep 1
+			curl -k --silent --fail -X POST "https://$SUBDOMAIN/indexes/test/documents" --data '[{"id":"doc1","description":"foo"},{"id":"doc2","description":"foo2"}]' --header "$api_key" --resolve "$resolve"
+			sleep 1
+			nb_documents=$(curl -k --fail -X GET "https://$SUBDOMAIN/indexes/test/documents" --header "$api_key" --resolve "$resolve" | jq -r ". | length")
+			if [ "$nb_documents" -ne 2 ]
+			then
+				echo "Expected to have 2 documents"
+				exit 1
+			fi
+		fi
 	; Manifest
 		domain="domain.tld"
 		path="/path"
@@ -43,5 +57,5 @@ Notification=none
 		name=Merge pull request #13 from YunoHost-Apps/testing
 		manifest_arg=domain=DOMAIN&path=PATH&is_public=1&data_path=""&master_key="YUNOHOST-API-KEY-202020201456452135"&
 	; commit=adb788162e27a843d52582cb03106861e1b17c9c
-		name=From Version 0.15.0ynh~1 (Fixes #14)
+		name=Version 0.15.0ynh~1 (Fixes #14)
 		manifest_arg=domain=DOMAIN&path=PATH&is_public=1&data_path=""&master_key="YUNOHOST-API-KEY-202020201456452135"&environment=development

--- a/check_process
+++ b/check_process
@@ -44,4 +44,4 @@ Notification=none
 		manifest_arg=domain=DOMAIN&path=PATH&is_public=1&data_path=""&master_key="YUNOHOST-API-KEY-202020201456452135"&
 	; commit=adb788162e27a843d52582cb03106861e1b17c9c
 		name=From Version 0.15.0ynh~1 (Fixes #14)
-		manifest_arg=domain=DOMAIN&path=PATH&is_public=1&data_path=""&master_key="YUNOHOST-API-KEY-202020201456452135"&
+		manifest_arg=domain=DOMAIN&path=PATH&is_public=1&data_path=""&master_key="YUNOHOST-API-KEY-202020201456452135"&environment=development

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -7,7 +7,7 @@ Type=simple
 User=__APP__
 Group=__APP__
 WorkingDirectory=__FINALPATH__/
-ExecStart=/usr/bin/meilisearch --http-addr 127.0.0.1:__PORT__ --env production --master-key __MASTER_KEY__ --no-analytics __ANALYTICS__
+ExecStart=/usr/bin/meilisearch --http-addr 127.0.0.1:__PORT__ --env __ENVIRONMENT__ --master-key __MASTER_KEY__ --no-analytics __ANALYTICS__
 
 [Install]
 WantedBy=multi-user.target

--- a/manifest.json
+++ b/manifest.json
@@ -42,6 +42,16 @@
         "example": "API-key245678635248795"
       },
       {
+        "name": "environment",
+        "type": "string",
+        "choices": ["development", "production"],
+        "default": "development",
+        "ask": {
+          "en": "Choose whether your instance run in production mode or in development mode (which brings an UI)",
+          "fr": "Choisissez si votre instance tourne en mode production ou développement (lequel offre une interface graphique)"
+        }
+      },
+      {
         "name": "allow_analyse",
         "type": "boolean",
         "ask": {

--- a/scripts/install
+++ b/scripts/install
@@ -29,6 +29,7 @@ path_url="/"
 is_public=$YNH_APP_ARG_IS_PUBLIC
 master_key=$YNH_APP_ARG_MASTER_KEY
 allow_analyse=$YNH_APP_ARG_ALLOW_ANALYSE
+environment=$YNH_APP_ARG_ENVIRONMENT
 
 app=$YNH_APP_INSTANCE_NAME
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -31,6 +31,7 @@ app=$YNH_APP_INSTANCE_NAME
 domain=$(ynh_app_setting_get --app=$app --key=domain)
 path_url=$(ynh_app_setting_get --app=$app --key=path)
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)
+environment=$(ynh_app_setting_get --app=$app --key=environment)
 
 #=================================================
 # CHECK IF THE APP CAN BE RESTORED

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -22,6 +22,7 @@ path_url=$(ynh_app_setting_get --app=$app --key=path)
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 master_key=$(ynh_app_setting_get --app=$app --key=master_key)
 allow_analyse=$(ynh_app_setting_get --app=$app --key=allow_analyse)
+environment=$(ynh_app_setting_get --app=$app --key=environment)
 
 # Variables used for dumps
 DUMPS_DIR="$(mktemp -d -t meilisearch_dumps.XXXXX)"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -148,14 +148,6 @@ chmod -R o-rwx "$final_path"
 chown -R $app:www-data "$final_path"
 
 #=================================================
-# STORE THE CONFIG FILE CHECKSUM
-#=================================================
-
-ynh_backup_if_checksum_is_different --file="$final_path/CONFIG_FILE"
-# Recalculate and store the checksum of the file for the next upgrade.
-ynh_store_file_checksum --file="$final_path/CONFIG_FILE"
-
-#=================================================
 # SETUP SYSTEMD
 #=================================================
 ynh_script_progression --message="Configuring a systemd service..." --weight=2

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -180,7 +180,10 @@ yunohost service add $app --description="Opensource next generation search API" 
 #=================================================
 ynh_script_progression --message="Import the dump..." --weight=3
 
-if [ "$upgrade_type" == "UPGRADE_APP" ]
+if [ ${#displayed_attributes[@]} -eq 0 ]
+then
+    ynh_print_warn --message="No index found, database probably empty, skip"
+elif [ "$upgrade_type" == "UPGRADE_APP" ]
 then
     tmp_dump_logs="$(mktemp -p $DUMPS_DIR)"
     ynh_debug --message="Running import command"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -96,7 +96,8 @@ then
     do
         sleep 5
     done
-    cp $final_path/dumps/$dump_id.tar.gz $DUMPS_DIR
+    # Depending on the version, the dump extension can be either a .tar.gz or a .dump (both are actually .tar.gz files)
+    mv $final_path/dumps/$dump_id.* $DUMPS_DIR
     ynh_print_info --message="Dumping done!"
 fi
 
@@ -191,7 +192,7 @@ if [ "$upgrade_type" == "UPGRADE_APP" ]
 then
     tmp_dump_logs="$(mktemp -p $DUMPS_DIR)"
     ynh_debug --message="Running import command"
-    /usr/bin/meilisearch --db-path $DUMPS_DIR/data.ms --import-dump $DUMPS_DIR/$dump_id.tar.gz --master-key $master_key --http-addr 127.0.0.1:$port --no-analytics true &> $tmp_dump_logs &
+    /usr/bin/meilisearch --db-path $DUMPS_DIR/data.ms --import-dump $DUMPS_DIR/$dump_id.* --master-key $master_key --http-addr 127.0.0.1:$port --no-analytics true &> $tmp_dump_logs &
     dump_pid=$!
     dump_timeout=300
     for i in $(seq $dump_timeout)

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -192,12 +192,13 @@ if [ "$upgrade_type" == "UPGRADE_APP" ]
 then
     tmp_dump_logs="$(mktemp -p $DUMPS_DIR)"
     ynh_debug --message="Running import command"
+    dump=$(find $DUMPS_DIR -name "$dump_id.tar.gz" -o -name "$dump_id.dump" | head -1)
     /usr/bin/meilisearch --db-path $DUMPS_DIR/data.ms --import-dump $DUMPS_DIR/$dump_id.* --master-key $master_key --http-addr 127.0.0.1:$port --no-analytics true &> $tmp_dump_logs &
     dump_pid=$!
     dump_timeout=300
     for i in $(seq $dump_timeout)
     do
-        if grep --quiet 'Dump importation from ".*" succeed' $tmp_dump_logs;
+        if [ "$(curl --silent -X GET "$BASE_URL/health" | jq -r ".status")" == "available" ]
         then
             ynh_debug --message="Importation succeeded"
             break

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -23,11 +23,21 @@ final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 master_key=$(ynh_app_setting_get --app=$app --key=master_key)
 allow_analyse=$(ynh_app_setting_get --app=$app --key=allow_analyse)
 
+# Variables used for dumps
+DUMPS_DIR="$(mktemp -d -t meilisearch_dumps.XXXXX)"
+declare -a dump_files=()
+declare -A displayed_attributes=()
+BASE_URL="http://localhost:$port"
+HEADER_API_KEY="X-Meili-API-Key: $master_key"
 #=================================================
 # CHECK VERSION
 #=================================================
 
-upgrade_type=$(ynh_check_app_version_changed)
+if ynh_compare_current_package_version --comparison lt --version 0.15.0~ynh1; then
+  ynh_die --message="Please upgrade from version 0.15 or above"
+else
+  upgrade_type=$(ynh_check_app_version_changed)
+fi
 
 #=================================================
 # BACKUP BEFORE UPGRADE THEN ACTIVE TRAP
@@ -37,8 +47,9 @@ ynh_script_progression --message="Backing up Meilisearch before upgrading (may t
 # Backup the current version of the app
 ynh_backup_before_upgrade
 ynh_clean_setup () {
-	# restore it if the upgrade fails
-	ynh_restore_upgradebackup
+    ynh_secure_remove --file=$DUMPS_DIR
+    # restore it if the upgrade fails
+    ynh_restore_upgradebackup
 }
 # Exit if an error occurs during the execution of the script
 ynh_abort_if_errors
@@ -59,6 +70,33 @@ if ynh_legacy_permissions_exists; then
 	ynh_legacy_permissions_delete_all
 
 	ynh_app_setting_delete --app=$app --key=is_public
+fi
+
+#=================================================
+# DUMP DATA
+#=================================================
+ynh_script_progression --message="Dump the database for migration if application version changed" --weight=1
+if [ "$upgrade_type" == "UPGRADE_APP" ]
+then
+    ynh_print_info --message="Version changed, beginning dumping"
+    ynh_debug --message="Fetching the index ids"
+    indexes_id=$(curl -s -X GET "$BASE_URL/indexes" --header "$HEADER_API_KEY" | jq -r '.[].uid')
+    for index in $indexes_id
+    do
+        # store the displayed_attributes before temporarily removing them
+        displayed_attributes+=([$index]="$(curl --fail --silent -X GET "$BASE_URL/indexes/$index/settings/displayed-attributes" --header "$HEADER_API_KEY")")
+        # Remove the displayed_attributes for the dump:
+        curl --silent --fail -X DELETE "$BASE_URL/indexes/$index/settings/displayed-attributes" --header "$HEADER_API_KEY"
+    done
+    ynh_debug --message="Requesting the Dump"
+    dump_id=$(curl --silent --fail -X POST "$BASE_URL/dumps" --header "$HEADER_API_KEY" | jq -r ".uid")
+    ynh_debug --message="Waiting for dump #$dump_id to be available"
+    while [ "$(curl --silent --fail -X GET "$BASE_URL/dumps/$dump_id/status" --header "$HEADER_API_KEY" | jq -r ".status")" != "done" ]
+    do
+        sleep 5
+    done
+    cp $final_path/dumps/$dump_id.tar.gz $DUMPS_DIR
+    ynh_print_info --message="Dumping done!"
 fi
 
 #=================================================
@@ -89,7 +127,7 @@ ynh_system_user_create --username=$app --home_dir="$final_path"
 #=================================================
 # UPGRADING MEILISEARCH
 #=================================================
-ynh_script_progression --message="upgrading Meilisearch..." --weight=5
+ynh_script_progression --message="Upgrading Meilisearch..." --weight=5
 
 arch=$(ynh_detect_arch)
 
@@ -97,6 +135,7 @@ if [ "$arch" != "amd64" ] && [ "$arch" != "armv8" ]
 then
     ynh_die --message="Your OS Architecture is not supported"
 fi
+
 release_file=meilisearch-linux-$arch
 curl -sOL https://github.com/meilisearch/MeiliSearch/releases/download/$latest/meilisearch-linux-$arch
 chmod +x "$release_file"
@@ -143,6 +182,52 @@ ynh_use_logrotate --non-append
 yunohost service add $app --description="Opensource next generation search API" --log="/var/log/$app/$app.log"
 
 #=================================================
+# IMPORT DUMP
+#=================================================
+ynh_script_progression --message="Import the dump..." --weight=3
+
+if [ "$upgrade_type" == "UPGRADE_APP" ]
+then
+    tmp_dump_logs="$(mktemp -p $DUMPS_DIR)"
+    ynh_debug --message="Running import command"
+    /usr/bin/meilisearch --db-path $DUMPS_DIR/data.ms --import-dump $DUMPS_DIR/$dump_id.tar.gz --master-key $master_key --http-addr 127.0.0.1:$port --no-analytics true &> $tmp_dump_logs &
+    dump_pid=$!
+    dump_timeout=300
+    for i in $(seq $dump_timeout)
+    do
+        if grep --quiet 'Dump importation from ".*" succeed' $tmp_dump_logs;
+        then
+            ynh_debug --message="Importation succeeded"
+            break
+        fi
+        if ! kill -0 $dump_pid &>/dev/null
+        then
+            ynh_die "The dump importation failed: $(cat $tmp_dump_logs)"
+        fi
+        if [ $i -eq 30 ]
+        then
+            ynh_print_warn --message="(Importation may take some time)"
+        fi
+        sleep 1
+    done
+    ynh_debug --message="Restore displayed_attributes"
+    for index in ${!displayed_attributes[*]}
+    do
+        curl --silent --fail -X POST "$BASE_URL/indexes/$index/settings/displayed-attributes" --data "${displayed_attributes[$index]}" --header "$HEADER_API_KEY"
+    done
+    sleep 1 # let meilisearch process the above requests
+    kill -SIGTERM $dump_pid
+    [ $i -eq $dump_timeout ] && ynh_die "The importation failed, abort!"
+    ynh_secure_remove --file=$final_path/data.ms
+    mv $DUMPS_DIR/data.ms $final_path/data.ms
+
+    chmod 750 "$final_path"
+    chmod -R o-rwx "$final_path"
+    chown -R $app:www-data "$final_path"
+    ynh_secure_remove --file=$DUMPS_DIR
+fi
+
+#=================================================
 # START SYSTEMD SERVICE
 #=================================================
 ynh_script_progression --message="Starting a systemd service..." --weight=3
@@ -160,4 +245,4 @@ ynh_systemd_action --service_name=nginx --action=reload
 # END OF SCRIPT
 #=================================================
 
-ynh_script_progression --message="Upgrade of Meilisearch completed" --last
+ynh_script_progression --message="Upgrade of Meilisearch completed"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -17,6 +17,7 @@ ynh_script_progression --message="Loading installation settings..." --weight=1
 app=$YNH_APP_INSTANCE_NAME
 
 domain=$(ynh_app_setting_get --app=$app --key=domain)
+port=$(ynh_app_setting_get --app=$app --key=port)
 path_url=$(ynh_app_setting_get --app=$app --key=path)
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 master_key=$(ynh_app_setting_get --app=$app --key=master_key)
@@ -59,15 +60,6 @@ if ynh_legacy_permissions_exists; then
 
 	ynh_app_setting_delete --app=$app --key=is_public
 fi
-
-#=================================================
-# FIND AND OPEN A PORT
-#=================================================
-ynh_script_progression --message="Finding an available port.." --weight=2
-
-# Find an available port
-port=$(ynh_find_port --port=8095)
-ynh_app_setting_set --app=$app --key=port --value=$port
 
 #=================================================
 # STANDARD UPGRADE STEPS

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -246,4 +246,4 @@ ynh_systemd_action --service_name=nginx --action=reload
 # END OF SCRIPT
 #=================================================
 
-ynh_script_progression --message="Upgrade of Meilisearch completed"
+ynh_script_progression --message="Upgrade of Meilisearch completed" --last


### PR DESCRIPTION
## Problem

- See #14: if you install meilisearch in version 0.15, index some document and then upgrade, meilisearch won't start
- An UI is missing after the upgrade (we only get JSON)
- Another port is used after each upgrade

## Solution

- A dump is produced and then consumed after the upgrade. Also add a commit of version 0.15 from which we try an upgrade.
- The option environment is added to the manifest, so one can choose `development` to get an UI
- Get the port used during the installation

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable) ⇒ DONE with a large database

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
