### PR TITLE
Upgrade to v1.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It shall NOT be edited by hand.
 Lightning Fast, Ultra Relevant, and Typo-Tolerant Search Engine
 
 
-**Shipped version:** 1.12.8~ynh1
+**Shipped version:** 1.13.0~ynh1
 
 **Demo:** <https://where2watch.meilisearch.com/>
 

--- a/README_es.md
+++ b/README_es.md
@@ -21,7 +21,7 @@ No se debe editar a mano.
 Lightning Fast, Ultra Relevant, and Typo-Tolerant Search Engine
 
 
-**Versión actual:** 1.12.8~ynh1
+**Versión actual:** 1.13.0~ynh1
 
 **Demo:** <https://where2watch.meilisearch.com/>
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -21,7 +21,7 @@ EZ editatu eskuz.
 Lightning Fast, Ultra Relevant, and Typo-Tolerant Search Engine
 
 
-**Paketatutako bertsioa:** 1.12.8~ynh1
+**Paketatutako bertsioa:** 1.13.0~ynh1
 
 **Demoa:** <https://where2watch.meilisearch.com/>
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -20,7 +20,7 @@ Il NE doit PAS être modifié à la main.
 
 Un moteur de recherche open source, ultra-rapide et hyper pertinent qui s'intègre sans effort à votre flux de travail.
 
-**Version incluse :** 1.12.8~ynh1
+**Version incluse :** 1.13.0~ynh1
 
 **Démo :** <https://where2watch.meilisearch.com/>
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -21,7 +21,7 @@ NON debe editarse manualmente.
 Lightning Fast, Ultra Relevant, and Typo-Tolerant Search Engine
 
 
-**Versión proporcionada:** 1.12.8~ynh1
+**Versión proporcionada:** 1.13.0~ynh1
 
 **Demo:** <https://where2watch.meilisearch.com/>
 

--- a/README_id.md
+++ b/README_id.md
@@ -21,7 +21,7 @@ Ini TIDAK boleh diedit dengan tangan.
 Lightning Fast, Ultra Relevant, and Typo-Tolerant Search Engine
 
 
-**Versi terkirim:** 1.12.8~ynh1
+**Versi terkirim:** 1.13.0~ynh1
 
 **Demo:** <https://where2watch.meilisearch.com/>
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -21,7 +21,7 @@ Hij mag NIET handmatig aangepast worden.
 Lightning Fast, Ultra Relevant, and Typo-Tolerant Search Engine
 
 
-**Geleverde versie:** 1.12.8~ynh1
+**Geleverde versie:** 1.13.0~ynh1
 
 **Demo:** <https://where2watch.meilisearch.com/>
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -21,7 +21,7 @@ Nie powinno być ono edytowane ręcznie.
 Lightning Fast, Ultra Relevant, and Typo-Tolerant Search Engine
 
 
-**Dostarczona wersja:** 1.12.8~ynh1
+**Dostarczona wersja:** 1.13.0~ynh1
 
 **Demo:** <https://where2watch.meilisearch.com/>
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -21,7 +21,7 @@
 Lightning Fast, Ultra Relevant, and Typo-Tolerant Search Engine
 
 
-**Поставляемая версия:** 1.12.8~ynh1
+**Поставляемая версия:** 1.13.0~ynh1
 
 **Демо-версия:** <https://where2watch.meilisearch.com/>
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -21,7 +21,7 @@
 Lightning Fast, Ultra Relevant, and Typo-Tolerant Search Engine
 
 
-**分发版本：** 1.12.8~ynh1
+**分发版本：** 1.13.0~ynh1
 
 **演示：** <https://where2watch.meilisearch.com/>
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "MeiliSearch"
 description.en = "Lightning Fast, Ultra Relevant, and Typo-Tolerant Search Engine"
 description.fr = "Moteur de recherche rapide, ultra-performant et tolérant aux fautes de frappe"
 
-version = "1.12.8~ynh1"
+version = "1.13.0~ynh1"
 
 maintainers = ["Julien Gomes Dias"]
 
@@ -42,10 +42,10 @@ ram.runtime = "50M"
     [resources.sources]
 
         [resources.sources.main]
-        amd64.url = "https://github.com/meilisearch/meilisearch/releases/download/v1.12.8/meilisearch-linux-amd64"
-        amd64.sha256 = "c325630ea967462e397899bb733a9fb599b89dcc112f8c5cb44d73ac0f16c553"
-        arm64.url = "https://github.com/meilisearch/meilisearch/releases/download/v1.12.8/meilisearch-linux-aarch64"
-        arm64.sha256 = "bea0346b76d354508e8f471b835e472452b0fa8be667fa78727b9b8e4318cc59"
+        amd64.url = "https://github.com/meilisearch/meilisearch/releases/download/v1.13.0/meilisearch-linux-amd64"
+        amd64.sha256 = "d6900108e66384b0b842f2596f71f65fa64594f4af760c42530eded82b996b0a"
+        arm64.url = "https://github.com/meilisearch/meilisearch/releases/download/v1.13.0/meilisearch-linux-aarch64"
+        arm64.sha256 = "9174008285dff69cd35110601ab97b83ce877892465c2c1d2b9d0b8b0e534569"
         rename = "meilisearch"
         in_subdir = false
         extract = false

--- a/tests.toml
+++ b/tests.toml
@@ -1,6 +1,12 @@
+#:schema https://raw.githubusercontent.com/YunoHost/apps/master/schemas/tests.v1.schema.json
+
 test_format = 1.0
 
 [default]
+
+    # ------------
+    # Tests to run
+    # ------------
 
     # -------------------------------
     # Default args to use for install
@@ -10,4 +16,4 @@ test_format = 1.0
     # Commits to test upgrade from
     # -------------------------------
 
-    #test_upgrade_from.30d48110ea0c820c89ab8ade34e415f07b5b0b86.name = "Upgrade from #13"
+    # test_upgrade_from.bd789664b890960b74126e60ceb82e3f7ea05f01.name = "Upgrade from 1.12.8~ynh1"


### PR DESCRIPTION
Upgrade sources
- `main` v1.13.0: https://github.com/meilisearch/meilisearch/releases/tag/v1.13.0

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
